### PR TITLE
0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.1.4] - 31th of August 2020
+
+- DependencyVisitor: add ability to define search order (get order from the `dependencyTypes` field)
+- DependencyType: new value: `DependencyType.root`
+- DependencyFile: new field: `absolutePath`
+
 ## [0.1.3] - 17th of August 2020
 
 - Add ability to search multiple files

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # DependencyVisitor
 
-Visits root package, transitive and immediate dependencies in order to search given file.
+Visits root package, transitive and immediate dependencies in order to search given files.
 
 
 ## Implementation

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.2"
+    version: "0.1.4"
   effective_dart:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: equatable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.4"
   functional_data:
     dependency: transitive
     description:

--- a/lib/dependency_visitor.dart
+++ b/lib/dependency_visitor.dart
@@ -1,7 +1,7 @@
 /// Visits root package, transitive and immediate dependencies
-/// in order to search given file
+/// in order to search given files.
 library dependency_visitor;
 
 export 'package:dependency_visitor/src/dependency_visitor.dart';
-export 'package:pubspec_lock/src/package_dependency/dependency_type/definition.dart';
 export 'package:dependency_visitor/src/models/dependency_file.dart';
+export 'package:dependency_visitor/src/models/enums/dependency_type.dart';

--- a/lib/src/models/dependency_file.dart
+++ b/lib/src/models/dependency_file.dart
@@ -3,18 +3,22 @@ import 'package:meta/meta.dart';
 
 /// Keeps info about founded file.
 class DependencyFile extends Equatable {
-  /// Name of package, where file has been found.
+  /// Name of package, where this file has been found.
   final String packageName;
 
-  /// Content of that file.
+  /// Content of this file.
   final String content;
+
+  /// Absolute path of this file.
+  final String absolutePath;
 
   /// Creates an instance of [DependencyFile]
   const DependencyFile({
     @required this.packageName,
     @required this.content,
+    @required this.absolutePath,
   });
 
   @override
-  List<Object> get props => [packageName, content];
+  List<Object> get props => [packageName, content, absolutePath];
 }

--- a/lib/src/models/enums/dependency_type.dart
+++ b/lib/src/models/enums/dependency_type.dart
@@ -1,0 +1,14 @@
+/// Dependency type specified by "dependency" keys in pubspec.lock files
+enum DependencyType {
+  /// Root package
+  root,
+
+  /// Specified as "direct main" dependencies in pubspec.lock files
+  direct,
+
+  /// Specified as "direct dev" in pubspec.lock files
+  development,
+
+  /// Specified as "transitive" in pubspec.lock files
+  transitive,
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,7 +98,7 @@ packages:
       name: equatable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.4"
   functional_data:
     dependency: transitive
     description:
@@ -266,7 +266,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.9"
   shelf_packages_handler:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dependency_visitor
-description: Visits root package, transitive and immediate dependencies in order to search given file.
-version: 0.1.3
+description: Visits root package, transitive and immediate dependencies in order to search given files.
+version: 0.1.4
 homepage: https://github.com/owczaro/dependency_visitor
 
 environment:
@@ -10,7 +10,7 @@ dependencies:
   effective_dart: ^1.2.4
   path: ^1.7.0
   yaml: ^2.2.1
-  equatable: ^1.2.3
+  equatable: ^1.2.4
   pubspec_lock: ^2.0.1
   meta: ^1.2.2
   universal_io: ^1.0.1

--- a/test/src/dependency_visitor_test.dart
+++ b/test/src/dependency_visitor_test.dart
@@ -1,16 +1,107 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
 import 'package:dependency_visitor/dependency_visitor.dart';
 import 'package:test/test.dart';
 
 /// Tests [DependencyVisitor]
 
 void main() {
-  group('PubCacheService', () {
-    test('Test responses', () async {
-      var stream = DependencyVisitor(filePaths: ['LICENSE']).run();
-      stream.forEach((element) {
-        expect(element.packageName, hasLength(greaterThan(0)));
-        expect(element.content, hasLength(greaterThan(0)));
+  group('DependencyVisitor', () {
+    test('Basic settings', () async {
+      await DependencyVisitor(filePaths: ['LICENSE'])
+          .run()
+          .forEach((dependencyFile) {
+        expect(dependencyFile.packageName, hasLength(greaterThan(0)));
+        expect(dependencyFile.content, hasLength(greaterThan(0)));
+        expect(dependencyFile.absolutePath, hasLength(greaterThan(0)));
       });
+    });
+
+    test('Does not include root - deprecated', () async {
+      final thisPackageLicenseAbsolutePath =
+          p.normalize('${Directory.current.absolute.path}/LICENSE');
+
+      await DependencyVisitor(filePaths: ['LICENSE'], includeRoot: false)
+          .run()
+          .forEach((dependencyFile) {
+        expect(dependencyFile.packageName, hasLength(greaterThan(0)));
+        expect(dependencyFile.content, hasLength(greaterThan(0)));
+        expect(dependencyFile.absolutePath, hasLength(greaterThan(0)));
+        expect(
+            dependencyFile.absolutePath, isNot(thisPackageLicenseAbsolutePath));
+      });
+    });
+
+    test('Does not include root', () async {
+      final thisPackageLicenseAbsolutePath =
+          p.normalize('${Directory.current.absolute.path}/LICENSE');
+
+      await DependencyVisitor(filePaths: [
+        'LICENSE'
+      ], dependencyTypes: [
+        DependencyType.development,
+        DependencyType.transitive,
+        DependencyType.direct,
+      ]).run().forEach((dependencyFile) {
+        expect(dependencyFile.packageName, hasLength(greaterThan(0)));
+        expect(dependencyFile.content, hasLength(greaterThan(0)));
+        expect(dependencyFile.absolutePath, hasLength(greaterThan(0)));
+        expect(
+            dependencyFile.absolutePath, isNot(thisPackageLicenseAbsolutePath));
+      });
+    });
+
+    test('File that does not exist', () async {
+      await DependencyVisitor(filePaths: ['asdksdv-does-not-exts.oq.test'])
+          .run()
+          .forEach((dependencyFile) {
+        expect(false, isTrue);
+      });
+    });
+  });
+  group('DependencyVisitor - Dependency Type', () {
+    var root = 0;
+    var direct = 0;
+    var development = 0;
+    var transitive = 0;
+
+    setUpAll(() async {
+      await DependencyVisitor(
+        filePaths: ['LICENSE'],
+        dependencyTypes: [DependencyType.root],
+      ).run().forEach((dependencyFile) => root++);
+
+      await DependencyVisitor(
+        filePaths: ['LICENSE'],
+        dependencyTypes: [DependencyType.development],
+      ).run().forEach((dependencyFile) => development++);
+
+      await DependencyVisitor(
+        filePaths: ['LICENSE'],
+        dependencyTypes: [DependencyType.direct],
+      ).run().forEach((dependencyFile) => direct++);
+
+      await DependencyVisitor(
+        filePaths: ['LICENSE'],
+        dependencyTypes: [DependencyType.transitive],
+      ).run().forEach((dependencyFile) => transitive++);
+    });
+
+    test('root = 1', () async {
+      expect(root, equals(1));
+    });
+
+    test('development > 0', () async {
+      expect(development, greaterThan(0));
+    });
+
+    test('development less than direct', () async {
+      expect(development, lessThan(direct));
+    });
+
+    test('direct less than transitive', () async {
+      expect(direct, lessThan(transitive));
     });
   });
 }

--- a/test/src/models/dependency_file_test.dart
+++ b/test/src/models/dependency_file_test.dart
@@ -9,6 +9,7 @@ void main() {
     dependencyFile = DependencyFile(
       packageName: 'package-name',
       content: 'Some content',
+      absolutePath: 'Absolute path',
     );
   });
   group('[Models] DependencyFile', () {

--- a/test/src/models/enums/dependency_type_test.dart
+++ b/test/src/models/enums/dependency_type_test.dart
@@ -1,0 +1,30 @@
+import 'package:dependency_visitor/src/models/enums/dependency_type.dart';
+import 'package:test/test.dart';
+
+/// Tests [DependencyType]
+
+Future main() async {
+  group('[Models/Enums] DependencyType', () {
+    test('Values count', () async {
+      expect(DependencyType.values.length, equals(4));
+    });
+
+    test('DependencyType.root', () async {
+      expect(DependencyType.root.toString(), equals('DependencyType.root'));
+    });
+
+    test('DependencyType.direct', () async {
+      expect(DependencyType.direct.toString(), equals('DependencyType.direct'));
+    });
+
+    test('DependencyType.development', () async {
+      expect(DependencyType.development.toString(),
+          equals('DependencyType.development'));
+    });
+
+    test('DependencyType.transitive', () async {
+      expect(DependencyType.transitive.toString(),
+          equals('DependencyType.transitive'));
+    });
+  });
+}


### PR DESCRIPTION
- DependencyVisitor: add ability to define search order (get order from the `dependencyTypes` field)
- DependencyType: new value: `DependencyType.root`
- DependencyFile: new field: `absolutePath`